### PR TITLE
feat: extend currency variable to ISO-4217 values

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "currency" {
   description = "Currency to be used for the budget"
   default     = "EUR"
   validation {
-    condition     = contains(["USD", "EUR"], var.currency)
-    error_message = "Must be either USD or EUR"
+    condition     = can(regex("^[A-Z]{3}$", var.currency))
+    error_message = "Must be a valid three-letter ISO-4217 currency code (e.g., USD, EUR)."
   }
 }


### PR DESCRIPTION
Resolves the limitation to `EUR` and `USD` previously put upon the `currency` variable, now extending it to all valid [ISO-4217](https://www.iso.org/iso-4217-currency-codes.html) values as per the GCP terraform documentation for [`currency_code`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_budget#currency_code-1).

Closes #52